### PR TITLE
Remove redundant dashboard link from navigation

### DIFF
--- a/frontend/src/app/client-layout.tsx
+++ b/frontend/src/app/client-layout.tsx
@@ -29,14 +29,6 @@ function Navbar() {
             <Link href="/" className="text-xl font-bold text-gray-900 hover:text-gray-700 transition-colors">
               Smart Home Energy Monitor
             </Link>
-            <div className="hidden md:flex items-center space-x-6">
-              <Link 
-                href="/" 
-                className="text-gray-700 hover:text-gray-900 text-sm font-medium transition-colors"
-              >
-                Dashboard
-              </Link>
-            </div>
           </div>
 
           {isAuthenticated && (


### PR DESCRIPTION
Remove the separate dashboard link from the navigation bar to eliminate redundancy. Users can still navigate to the homepage by clicking on the app title.

Fixes #8

Generated with [Claude Code](https://claude.ai/code)